### PR TITLE
feat: add nevo-ai Claude Code operational workflow layer

### DIFF
--- a/.claude/agents/nevo-ai-spec-researcher.md
+++ b/.claude/agents/nevo-ai-spec-researcher.md
@@ -1,0 +1,80 @@
+---
+name: nevo-ai-spec-researcher
+description: Read-only NEvo repository researcher for specification discovery. Finds current behavior, examples, package boundaries, tests, and documentation evidence without editing files or making architectural decisions.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are `nevo-ai-spec-researcher`, a project-local, read-only research subagent for the
+NEvo repository. You exist to answer factual questions during the discovery phase of
+`docs/ai/specification-workflow.md` without burning the main session's context on broad
+exploration.
+
+## What you do
+
+- Inspect code, project references, examples, tests, documentation
+  (`docs/architecture/`, `docs/development/`, `docs/ai/`, `docs/adr/`), and active specs
+  (`specs/active/`) to answer the question you were asked.
+- Collect facts and evidence — every claim you make must cite a repository-relative path
+  (and symbol name, line number, or test name where useful).
+- Separate your findings into four labeled sections:
+  - **Facts** — directly observed in code, tests, or docs.
+  - **Inferences** — a conclusion drawn from facts; label it as inference, never present
+    it as fact.
+  - **Inconsistencies** — places where sources disagree (doc vs. code, example vs.
+    test, spec vs. implementation).
+  - **Open questions** — things you could not determine from the repository and that
+    would need to be asked of the owner.
+- Return a concise report to the main session. Prefer precision over exhaustiveness — if
+  the question was narrow, answer it narrowly.
+
+## What you do not do
+
+- Do not offer recommendations or architectural opinions unless the calling agent
+  explicitly asked for them. If you weren't asked, stop at facts/inferences.
+- Do not edit or write any file.
+- Do not create, refine, or restructure specs.
+- Do not choose architecture or resolve an inconsistency on the repository's behalf —
+  report it and let the owner-facing command handle it.
+- Do not change any task or change status.
+- Do not create branches or commits.
+
+## Bash usage
+
+`Bash` is enabled for you, but restricted to non-mutating, read-only commands. Examples
+of what is in scope:
+
+- `git status`, `git log`, `git show`, `git diff`
+- `dotnet sln list`
+- listing/search commands (`dir`, `ls`, equivalents)
+- read-only invocations of repository tools, e.g. `node tools/docs.mjs find --scope
+  <scope>`, `node tools/docs.mjs validate`, `node tools/specs.mjs list`,
+  `node tools/specs.mjs validate`
+
+Do not run installation, package restore, formatting, code generation
+(`tools/docs.mjs generate`, `tools/specs.mjs generate`), branch creation, status
+transitions (`tools/specs.mjs start|complete|verify|archive`), build steps that write
+output, migrations, or any other command that changes repository or working-tree state.
+If you are unsure whether a command is read-only, do not run it — read the relevant file
+instead.
+
+## Output shape
+
+Structure every response as:
+
+```
+## Facts
+...
+
+## Inferences
+...
+
+## Inconsistencies
+...
+
+## Open questions
+...
+```
+
+Omit a section only if it is genuinely empty for the question asked (state "none found"
+rather than silently dropping the heading if that matters for the caller's record).

--- a/.claude/commands/nevo-ai/spec-create.md
+++ b/.claude/commands/nevo-ai/spec-create.md
@@ -1,0 +1,58 @@
+---
+description: Create a new human-led NEvo specification after repository discovery and explicit owner decisions.
+argument-hint: <change-id> <goal>
+disable-model-invocation: true
+---
+
+Read the shared skill `nevo-ai-spec-workflow` (`.claude/skills/nevo-ai-spec-workflow/SKILL.md`)
+if not already in context, plus `docs/ai/specification-workflow.md` and `AGENTS.md`.
+
+Arguments (`$ARGUMENTS`): `<change-id> <goal>` — a stable kebab-case slug and a short goal
+statement.
+
+## Flow
+
+1. Parse `<change-id>` and `<goal>` from `$ARGUMENTS`. Validate the id is a stable
+   kebab-case slug.
+2. Check whether `<change-id>` already exists under `specs/active/` or `specs/archive/`
+   (`node tools/specs.mjs list`, and a directory check for archive). If it does, stop and
+   report the collision instead of creating a duplicate.
+3. Use `node tools/docs.mjs find --scope <scope> --format json` (and `docs/index.generated.md`
+   if present) to resolve documentation likely relevant to the goal.
+4. Classify the change using the classes in `AGENTS.md` (S/T/A/E) — read
+   `references/artifact-policy.md` for the sizing rules behind this call.
+5. Perform discovery per `references/discovery-policy.md`. Delegate broad read-only
+   exploration to the `nevo-ai-spec-researcher` subagent when it would otherwise crowd
+   this session's context (facts and evidence only — it does not decide anything).
+6. Present, per `references/decision-policy.md`: repository facts, current behavior,
+   affected areas, constraints, open questions, meaningful options, one recommendation,
+   and the specific owner decisions required.
+7. **Stop and wait for the owner** whenever a material decision is required. Do not
+   proceed on an assumed answer.
+8. After the owner has explicitly answered:
+   - record the decisions using `templates/owner-decisions.md`,
+   - choose the smallest sufficient artifact structure per `references/artifact-policy.md`,
+   - create the change directory under `specs/active/<change-id>/` matching the schema
+     already used in this repo (`change.yaml`, `overview.md`, optional `areas/`,
+     `tasks/<n>-<id>.md`) — use `templates/standard-change.md`,
+     `templates/architectural-change.md`, `templates/area.md`, and `templates/task.md` as
+     guides, omitting sections they mark as optional,
+   - decompose large work into cohesive areas/tasks rather than one monolithic file,
+   - run `node tools/specs.mjs validate` (and `node tools/docs.mjs validate` if docs were
+     touched).
+9. Report: created/updated files, recorded owner decisions, any decisions still
+   unresolved, validation results, and the recommended next command
+   (typically `/nevo-ai:spec-review <change-id>`).
+
+## Non-negotiable rules
+
+- Do not implement source changes.
+- Do not start a task (`tools/specs.mjs start`) — that is `/nevo-ai:task-start`.
+- Do not create a branch unless the repository's approved workflow explicitly requires a
+  specification branch and the owner has approved it — normally no branch is created at
+  this stage.
+- Do not mark a specification `approved` on the owner's behalf.
+- Do not invent architecture the owner hasn't decided.
+- Do not create one large file when multiple independently implementable areas would
+  reduce context — see `references/artifact-policy.md`.
+- Do not create empty template files or sections that aren't required.

--- a/.claude/commands/nevo-ai/spec-refine.md
+++ b/.claude/commands/nevo-ai/spec-refine.md
@@ -1,0 +1,39 @@
+---
+description: Refine an existing active NEvo specification without implementing it.
+argument-hint: <change-id> [focus]
+disable-model-invocation: true
+---
+
+Read the shared skill `nevo-ai-spec-workflow` (`.claude/skills/nevo-ai-spec-workflow/SKILL.md`)
+if not already in context, plus `docs/ai/specification-workflow.md`.
+
+Arguments (`$ARGUMENTS`): `<change-id> [focus]` — the active change slug, and an optional
+focus area to narrow the refinement.
+
+## Flow
+
+1. Resolve the active change via `node tools/specs.mjs list` / `node tools/specs.mjs
+   context <change-id> <task-id>` as needed. Stop if `<change-id>` is not found in
+   `specs/active/`.
+2. Read its `change.yaml` manifest and current artifacts (`overview.md`, `areas/`,
+   `tasks/`).
+3. Load only related docs and ADRs — do not load the whole `docs/` tree
+   (`references/context-policy.md`).
+4. Detect, per `references/artifact-policy.md` and `references/review-policy.md`:
+   unresolved owner decisions, missing or untestable acceptance criteria, oversized
+   artifacts, missing area decomposition, duplicated requirements, task context bloat,
+   unclear dependencies, documentation impact, migration/compatibility gaps.
+5. Present the proposed refinements using the facts/inferences/recommendation/decision
+   separation from `references/decision-policy.md`.
+6. **Wait for owner approval** before applying any refinement that changes behavior,
+   scope, acceptance criteria, or architecture. Purely editorial fixes (typos, broken
+   links, formatting) may be applied and reported without a stop, if the owner's
+   invocation didn't already scope this command to read-only review.
+7. Apply only the approved updates. Record any new owner decisions via
+   `templates/owner-decisions.md`.
+8. Run `node tools/specs.mjs validate` (and `node tools/docs.mjs validate` if docs were
+   touched).
+9. Do not implement code — this command only edits specification artifacts under
+   `specs/active/<change-id>/`.
+
+Report: what was refined, what still needs an owner decision, and validation results.

--- a/.claude/commands/nevo-ai/spec-review.md
+++ b/.claude/commands/nevo-ai/spec-review.md
@@ -1,0 +1,32 @@
+---
+description: Read-only implementation-readiness review of a NEvo specification.
+argument-hint: <change-id>
+disable-model-invocation: true
+---
+
+Read the shared skill `nevo-ai-spec-workflow` (`.claude/skills/nevo-ai-spec-workflow/SKILL.md`)
+if not already in context, plus `references/review-policy.md`.
+
+Arguments (`$ARGUMENTS`): `<change-id>`.
+
+## Flow
+
+1. Resolve `<change-id>` under `specs/active/`. Read `change.yaml` and all its artifacts.
+2. Run `node tools/specs.mjs validate` to get mechanical dependency/cycle/id checks for
+   free — do not re-derive those by hand.
+3. Evaluate readiness per `references/review-policy.md` — "Specification readiness
+   criteria."
+4. Produce a structured review using `templates/review-report.md` as a guide, covering:
+   readiness verdict, blocking issues, owner decisions still required, ambiguity/
+   assumption risks, architecture conflicts, acceptance-criteria quality, task
+   decomposition quality, task dependency correctness, context-packet quality,
+   allowed/forbidden-path quality, documentation/ADR impact, and implementation
+   readiness per task.
+
+## Rules
+
+- This command is **read-only by default**. Do not edit any file.
+- Do not approve the change on the owner's behalf, and do not change any status.
+- If the owner explicitly asks this invocation to also apply fixes, apply only the
+  specific fixes requested, then re-report — do not expand into a general refinement
+  pass (use `/nevo-ai:spec-refine` for that).

--- a/.claude/commands/nevo-ai/task-next.md
+++ b/.claude/commands/nevo-ai/task-next.md
@@ -1,0 +1,34 @@
+---
+description: Return the next approved, dependency-ready NEvo task without starting it.
+argument-hint: "[filters]"
+disable-model-invocation: true
+---
+
+Arguments (`$ARGUMENTS`): optional filters, passed through to the CLI if supported.
+
+## Flow
+
+1. Run:
+
+```
+node tools/specs.mjs next
+```
+
+using only supported arguments — do not scan `specs/active/**` by hand before running
+the CLI.
+
+2. If it returns "No approved tasks ready," report that plainly. Do not pick a task
+   yourself.
+3. Otherwise, from the returned context packet, report: change ID, task ID, task status,
+   dependency status, proposed branch, required context files, a concise goal, and the
+   exact command to run next:
+
+```
+/nevo-ai:task-start <change-id> <task-id>
+```
+
+## Rules
+
+- Do not start or implement the task from this command.
+- Do not read the task file's full body here beyond what's needed to state a concise
+  goal — full context loading belongs to `/nevo-ai:task-start`.

--- a/.claude/commands/nevo-ai/task-review.md
+++ b/.claude/commands/nevo-ai/task-review.md
@@ -1,0 +1,33 @@
+---
+description: Review the current working tree against one approved NEvo task.
+argument-hint: <change-id> <task-id>
+disable-model-invocation: true
+---
+
+Read `references/review-policy.md` from the shared skill if not already in context.
+
+Arguments (`$ARGUMENTS`): `<change-id> <task-id>`.
+
+## Flow
+
+1. Run `node tools/specs.mjs context <change-id> <task-id>` to resolve the task's
+   context, `allowed_paths`, and `forbidden_paths`.
+2. Inspect `git diff` / `git status` for the changed files.
+3. Verify the diff stays within `allowed_paths` and does not touch `forbidden_paths`.
+4. Compare the implementation to: the task's acceptance criteria, its area's
+   requirements (if any), change-wide constraints, applicable ADRs, and architecture
+   documentation.
+5. Check behavior, tests, documentation impact, breaking changes, unrelated edits,
+   generated artifacts (`*.generated.*` should only change via `tools/docs.mjs
+   generate` / `tools/specs.mjs generate`), and verification evidence (build/test
+   output — ask for it if not shown).
+6. Produce a report using `templates/review-report.md` as a guide: pass/fail verdict,
+   blockers, non-blocking findings, missing tests, missing documentation, and the
+   recommended task status transition.
+
+## Rules
+
+- Do not change task status automatically — recommend the transition; the owner (or an
+  explicit follow-up instruction) applies it via `node tools/specs.mjs complete
+  <change-id> <task-id>` or `verify`.
+- Do not commit.

--- a/.claude/commands/nevo-ai/task-start.md
+++ b/.claude/commands/nevo-ai/task-start.md
@@ -1,0 +1,44 @@
+---
+description: Safely start one approved NEvo task and prepare its implementation context. Prepares and stages the task — does not silently finish it.
+argument-hint: <change-id> <task-id>
+disable-model-invocation: true
+---
+
+Read `references/context-policy.md` from the shared skill if not already in context.
+
+Arguments (`$ARGUMENTS`): `<change-id> <task-id>`.
+
+## Flow
+
+1. Run `git status`. If unrelated uncommitted changes make branch creation or status
+   mutation unsafe, stop and report — do not stash or discard anything without explicit
+   instruction.
+2. Run `node tools/specs.mjs context <change-id> <task-id>` to obtain the task context
+   packet.
+3. Verify: the task is `approved`, its `depends_on` are all in a terminal status, the
+   change is active, the task is not otherwise blocked, `allowed_paths` are present, and
+   `forbidden_paths` are understood.
+4. Show the owner: the exact task, the branch that will be created/switched to, the
+   files that will be loaded (`context.required`), the allowed scope, the forbidden
+   scope, and verification requirements from the task's acceptance criteria.
+5. Only after confirming the above is safe, run:
+
+```
+node tools/specs.mjs start <change-id> <task-id>
+```
+
+This creates/switches the branch and sets the task to `in-implementation` — do not
+create the branch manually.
+
+6. Load only the `context.required` files (load `context.optional` only if the task text
+   references them).
+7. Summarize the implementation plan.
+8. **Stop before making any source edits** and ask the owner to confirm implementation —
+   unless the owner's invocation of this command already included an explicit
+   implementation instruction recognized by the workflow (e.g. "start and implement
+   task X"). The default meaning of `task-start` is *prepare and start the task*, not
+   silently finish it.
+
+## Rules
+
+- Do not commit, push, or create a pull request from this command.

--- a/.claude/skills/nevo-ai-spec-workflow/SKILL.md
+++ b/.claude/skills/nevo-ai-spec-workflow/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: nevo-ai-spec-workflow
+description: Shared NEvo workflow for human-led discovery, specification, task decomposition, review, and task execution. Used by the namespaced /nevo-ai:* commands.
+user-invocable: false
+disable-model-invocation: true
+---
+
+# NEvo spec workflow (shared)
+
+This skill is the internal playbook behind the `/nevo-ai:*` commands. It is not invoked
+directly — the owner interacts through the namespaced commands, and each command loads
+this file plus only the reference(s) it needs.
+
+> If this Claude Code build does not honor `user-invocable: false` /
+> `disable-model-invocation: true`, this file may still surface directly. Treat it as
+> read-only background material in that case, not as something to run standalone —
+> always prefer the `/nevo-ai:*` command for the phase you are in.
+
+## The one source of truth
+
+The workflow itself — change classes, owner approval gates, discovery rules, artifact
+sizing, context packets, git safety — is defined in
+[`docs/ai/specification-workflow.md`](../../../docs/ai/specification-workflow.md), and in
+`AGENTS.md` for the decision-policy table. This skill does not repeat that content. Every
+`/nevo-ai:*` command must have read `docs/ai/specification-workflow.md` (or already have
+it in context) before acting.
+
+## Phase → reference map
+
+Load only the reference file(s) for the phase you are in — not all of them.
+
+| Phase | Reference | When |
+|---|---|---|
+| Discovery | `references/discovery-policy.md` | Any command starting fresh discovery (`spec-create`, and `spec-refine`/`spec-review` when evidence is stale) |
+| Presenting options / recording decisions | `references/decision-policy.md` | Any command about to ask the owner something, or record what they answered |
+| Choosing artifact shape | `references/artifact-policy.md` | `spec-create` (initial structure), `spec-refine` (detecting oversized/undersized artifacts) |
+| Loading context | `references/context-policy.md` | `task-next`, `task-start` |
+| Judging readiness / diffs | `references/review-policy.md` | `spec-review`, `task-review` |
+
+Templates in `templates/` are guides for artifact shape, not mandatory boilerplate —
+each template states which of its sections may be omitted. Use them when creating or
+restructuring specs, not as a checklist to paste verbatim.
+
+## Non-negotiable stop conditions
+
+Stop and wait for the owner — do not guess, do not proceed on the "likely" answer —
+whenever:
+
+- a decision falls under "Owner approval required" in `AGENTS.md`,
+- a specification would leave an acceptance criterion untestable or a dependency
+  ambiguous,
+- an existing source of truth (spec vs. ADR vs. architecture doc vs. code) conflicts
+  with another — report the conflict, do not silently pick one,
+- a command is about to cross from specification into implementation, or from review
+  into applying fixes, without the owner having asked for that explicitly.
+
+## Commands, this skill, and the CLI
+
+```
+owner
+  │  invokes
+  ▼
+/nevo-ai:* command  (thin, in .claude/commands/nevo-ai/)
+  │  reads
+  ▼
+this skill + the one reference it needs
+  │  calls, for anything deterministic
+  ▼
+tools/specs.mjs / tools/docs.mjs
+  │  delegates broad read-only exploration to
+  ▼
+nevo-ai-spec-researcher subagent (facts only, no decisions)
+```
+
+Commands never reimplement what the CLI already does deterministically (status
+transitions, branch creation, index generation, readiness checks). If a command needs
+information the CLI doesn't expose, read the specific file the context packet names —
+never scan the whole `specs/` or `docs/` tree by default.
+
+## Fact / inference / recommendation / decision separation
+
+Every command that presents findings to the owner must keep these visually and
+structurally separate:
+
+- **Facts** — directly observed (file exists, field has this value, test asserts this).
+- **Inferences** — a conclusion drawn from facts, clearly marked as such.
+- **Recommendation** — the agent's suggested path, with trade-offs, never presented as
+  already decided.
+- **Owner decisions** — what was actually decided, recorded via
+  `templates/owner-decisions.md`, never inferred from silence.
+
+## Preventing premature implementation
+
+`spec-create` and `spec-refine` never write source code, never run `tools/specs.mjs
+start`, and never mark a task `approved`. `spec-review` and `task-review` never edit
+files unless the owner explicitly asked for fixes to be applied. The transition from
+"specification" to "implementation" is always a separate, explicit owner-invoked step
+(`/nevo-ai:task-start`, then the owner's explicit go-ahead to write code).
+
+## Preventing oversized specifications
+
+Before writing a single large spec file, check whether the change has more than one
+independently implementable concern. If it does, decompose into `areas/` and per-area
+`tasks/` rather than one monolithic document — see `references/artifact-policy.md`. A
+single task's context packet should stay small enough that an implementing agent does
+not need to read the whole change to act on it.

--- a/.claude/skills/nevo-ai-spec-workflow/references/artifact-policy.md
+++ b/.claude/skills/nevo-ai-spec-workflow/references/artifact-policy.md
@@ -1,0 +1,55 @@
+# Artifact policy
+
+## Small vs. standard vs. architectural artifact sets
+
+Mirrors the change classes in `AGENTS.md`:
+
+- **S — Small**: no spec artifact. Only use this when the change truly needs no
+  discovery and no owner decision (a typo, a local rename, a test for existing behavior).
+- **T — Standard**: a single spec file (`templates/standard-change.md`) — problem,
+  current/desired behavior, constraints, owner decisions, acceptance criteria.
+- **A — Architectural**: a full change directory — `change.yaml` manifest,
+  `overview.md` (`templates/architectural-change.md`), optional `areas/<area>.md`
+  (`templates/area.md`), and `tasks/<n>-<id>.md` (`templates/task.md`) per implementable
+  unit of work.
+
+## When to split by area
+
+Split into `areas/` when the change has more than one concern that could reasonably be
+implemented (and reviewed) independently — different modules, different layers, or work
+that different tasks will touch without needing each other's full context. Do not split
+a change that is really one cohesive unit just to produce more files.
+
+## When an ADR is needed
+
+A new ADR is needed when the change makes a durable architectural decision that future
+changes will need to know about (a chosen pattern, a rejected alternative, a constraint
+that isn't obvious from the code alone). A change that merely follows an existing ADR
+does not need a new one. Superseding an existing ADR is an owner decision — propose it,
+do not do it unilaterally.
+
+## When architecture documentation must be updated
+
+If a change alters *current* behavior that `docs/architecture/` describes, the same
+change updates that document in the same branch — architecture docs describe current
+behavior, not a future aspiration, so they cannot be left stale after merge.
+
+## How to avoid empty boilerplate
+
+Every template file in `templates/` states which sections may be omitted. Omit them —
+do not paste a template with placeholder text like "N/A" or "TBD" just to look complete.
+An empty `areas/` directory or a task file with no real acceptance criteria is worse than
+not creating the file at all.
+
+## Active / archive rules
+
+New specs are always created in `specs/active/`. Never create directly in
+`specs/archive/`. A change moves to `specs/archive/` only via `node tools/specs.mjs
+archive <change>`, which itself refuses to run unless every task is in a terminal status.
+
+## Source-of-truth precedence
+
+When artifacts disagree, resolve using the precedence in `AGENTS.md` ("Source of truth
+precedence"): approved spec for the current change → accepted ADRs → current
+architecture docs → development rules → current implementation → generated indexes.
+Report conflicts rather than silently picking a level to trust.

--- a/.claude/skills/nevo-ai-spec-workflow/references/context-policy.md
+++ b/.claude/skills/nevo-ai-spec-workflow/references/context-policy.md
@@ -1,0 +1,46 @@
+# Context policy
+
+## Use the CLI before reading specs
+
+Always run `node tools/specs.mjs next` or `node tools/specs.mjs context <change> <task>`
+before reading spec files directly. The CLI resolves dependencies, readiness, and
+relative paths — do not replicate that logic by manually scanning `specs/active/`.
+
+## Load only required context
+
+From the context packet, read every file in `context.required`. Do not read anything
+else in the change directory unless it is also in `context.required`.
+
+## Optional context rules
+
+Read `context.optional` entries only if the task's own text references them (e.g. "see
+the overview for background on X"). Do not read optional context by default — it exists
+to be available, not to be loaded every time.
+
+## Archived-spec restrictions
+
+Do not read `specs/archive/**` as part of normal context loading. The only valid reasons
+are: the active task explicitly references an archived spec, the owner explicitly asks
+for historical reasoning, or an ADR/active spec requires it for context. State the reason
+when you do.
+
+## When full overview is necessary
+
+A full read of `overview.md` (beyond what `context.required` lists) is justified when:
+you are the `spec-review` or `spec-refine` command evaluating the whole change, not a
+single task; or a task's context is ambiguous enough that the overview is the only way
+to resolve it — in which case, say so rather than silently expanding scope.
+
+## How task context packets reduce token usage
+
+A task's `context.required`/`context.optional`/`allowed_paths`/`forbidden_paths` exist
+specifically so an implementing agent never needs the whole change loaded to act on one
+task. Treat a task that requires reading the entire change to make sense as a sign the
+change needs better decomposition (see `artifact-policy.md`), not as normal.
+
+## How to avoid repeated repository-wide exploration
+
+If discovery already established a fact (with citation), do not re-derive it in a later
+phase — carry it forward from the discovery report or owner-decisions record instead of
+re-scanning the codebase. Repository-wide exploration is a discovery-phase activity, not
+something every command redoes from scratch.

--- a/.claude/skills/nevo-ai-spec-workflow/references/decision-policy.md
+++ b/.claude/skills/nevo-ai-spec-workflow/references/decision-policy.md
@@ -1,0 +1,49 @@
+# Decision policy
+
+This references the owner-approval model in `AGENTS.md` ("Decision policy") and
+`docs/ai/specification-workflow.md` ("Owner approval gates") — it does not restate that
+list. This document is about the *operational mechanics* of presenting and recording
+decisions, not about which decisions require approval.
+
+## How to present options
+
+For each decision needed:
+- State the question in one sentence.
+- Give the meaningful options (not an exhaustive enumeration of every conceivable
+  variant) with their real trade-offs.
+- Note which option is least reversible, if that differs from the recommended one.
+
+## How to state a recommendation
+
+Give exactly one recommended option and the reason. A recommendation is a suggestion,
+not a decision — never act on it as if the owner had already agreed, and say so
+explicitly ("recommendation, not yet decided").
+
+## How to record owner decisions
+
+Once the owner responds, record it using `templates/owner-decisions.md`: decision ID,
+question, options considered, the actual decision, rationale if given, consequences, and
+which artifacts it affects. This record travels with the change (in its spec directory),
+not just in conversation — later commands (`spec-refine`, `task-review`) need it without
+replaying the whole discussion.
+
+## What may not be inferred
+
+- Silence is not agreement. An unanswered question stays open, it does not default to
+  the recommended option.
+- A decision made for one change does not silently apply to a different change, even a
+  similar one — ask again, referencing the precedent as context.
+- Do not infer a decision from an old commit, an old spec, or code shape alone — those
+  are evidence for a recommendation, not a substitute for the owner's answer.
+
+## How to handle unanswered questions
+
+List them explicitly as open in the discovery/review output. A specification with
+unresolved decisions that block a task is not ready for implementation — say so, don't
+paper over it with a plausible-sounding default.
+
+## Preventing suggestions from becoming requirements
+
+Never write a recommendation directly into a spec's acceptance criteria before the owner
+has approved it. Draft acceptance criteria are clearly marked as proposed until the
+owner decision that confirms them is recorded.

--- a/.claude/skills/nevo-ai-spec-workflow/references/discovery-policy.md
+++ b/.claude/skills/nevo-ai-spec-workflow/references/discovery-policy.md
@@ -1,0 +1,54 @@
+# Discovery policy
+
+## What discovery must inspect
+
+- Current behavior of the affected area: code, tests, examples — not assumptions about
+  what the code "probably" does.
+- Existing documentation: `docs/architecture/`, `docs/development/`, relevant `docs/adr/`
+  entries (use `node tools/docs.mjs find --scope <scope>` rather than reading everything).
+- Whether an active or archived change already covers this ground
+  (`node tools/specs.mjs list`, and `specs/archive/` only if there's reason to believe
+  prior work exists).
+- Constraints implied by accepted ADRs that touch the area.
+
+## When to use the research subagent
+
+Delegate to `nevo-ai-spec-researcher` when discovery would otherwise require reading many
+files just to establish facts (e.g. "how does the messaging pipeline currently handle
+retries", "what public surface does package X expose"). Do not delegate when the answer
+is already in the task's declared context, or when the question requires a judgment call
+— the researcher reports facts, it does not decide.
+
+## Evidence requirements
+
+Every factual claim in a discovery report must be traceable to a file path (and symbol
+name or line reference where useful). "The messaging pipeline retries on failure" is not
+evidence; "`MessagingPipeline.cs:142` catches `TransientException` and re-enqueues" is.
+
+## Fact versus inference
+
+- **Fact**: directly observed in code, tests, or docs.
+- **Inference**: a conclusion drawn from facts, e.g. "no test covers concurrent access,
+  so behavior under concurrency is unspecified." Always label inferences as such — never
+  present them as fact.
+
+## Examples versus tests
+
+Examples (`examples/`) show intended usage but are not a behavior contract — they can be
+stale or aspirational. Tests (`tests/`) are the actual behavior contract. When the two
+disagree, treat it as an inconsistency to report, not something to silently resolve by
+picking one.
+
+## Reporting stale docs
+
+If `docs/architecture/*` describes behavior that the code no longer matches, report it as
+an inconsistency with both citations (doc line, code line). Do not silently trust the
+doc, and do not silently trust the code — the owner decides which is authoritative going
+forward (this may itself require an ADR update).
+
+## When to stop discovery
+
+Stop once you can state, with evidence: current behavior, affected areas, constraints,
+and the open questions that remain. Do not keep exploring to "be thorough" once the
+material facts needed for a specification are established — bring the open questions to
+the owner instead of trying to resolve everything unilaterally.

--- a/.claude/skills/nevo-ai-spec-workflow/references/review-policy.md
+++ b/.claude/skills/nevo-ai-spec-workflow/references/review-policy.md
@@ -1,0 +1,55 @@
+# Review policy
+
+## Specification readiness criteria
+
+A spec is ready for implementation when:
+- every task intended to start next has `status: approved`,
+- `depends_on` references resolve and are not cyclic (`node tools/specs.mjs validate`
+  checks this mechanically — run it),
+- `allowed_paths` / `forbidden_paths` are present and unambiguous for every task,
+- acceptance criteria are testable (a build/test/behavior check can confirm them — not
+  aspirational language),
+- no owner decision needed for the next task is still open,
+- documentation impact (architecture docs, ADRs) is identified, even if deferred.
+
+## Implementation review criteria
+
+Compare the diff against: the task's acceptance criteria, its area's requirements (if
+any), change-wide constraints, applicable ADRs, and architecture documentation. Check
+behavior, tests, documentation impact, breaking changes, unrelated edits, generated
+artifacts (`*.generated.*` should only change via the generator commands), and
+verification evidence (build/test output).
+
+## Blocking versus non-blocking findings
+
+- **Blocking**: scope violation (edits outside `allowed_paths` or touching
+  `forbidden_paths`), missing acceptance-criteria coverage, missing tests for behavior
+  change, undocumented breaking change, architecture/ADR conflict not called out.
+- **Non-blocking**: style nits, suggestions for a follow-up, minor documentation
+  polish that doesn't affect correctness.
+
+## Architecture drift detection
+
+If the diff changes behavior that `docs/architecture/` describes, and the same branch
+does not update that document, this is a blocking finding — architecture docs must
+track current behavior.
+
+## Documentation drift detection
+
+If `docs/index.generated.*` or `specs/*.generated.*` are stale relative to their sources
+(`node tools/docs.mjs check` / `node tools/specs.mjs check` fail), this is a blocking
+finding — flag it rather than regenerating silently unless the owner asked for fixes to
+be applied.
+
+## Status recommendations
+
+Recommend a task status transition (e.g. "ready to mark `implemented`" or "should stay
+`in-implementation` — tests missing for X"), but do not change status yourself. Status
+changes go through `tools/specs.mjs complete` / `verify`, invoked by the owner or on
+explicit instruction.
+
+## Owner-only transitions
+
+Marking a spec "approved," marking a task "verified," and archiving a change are owner
+(or owner-instructed) actions. A review command states a recommendation; it does not
+perform the transition.

--- a/.claude/skills/nevo-ai-spec-workflow/templates/architectural-change.md
+++ b/.claude/skills/nevo-ai-spec-workflow/templates/architectural-change.md
@@ -1,0 +1,71 @@
+---
+id: spec.<change-slug>
+type: change
+title: <Title>
+status: draft
+change: <change-slug>
+---
+
+# <Title>
+
+Overview document for an Architectural (class A) change. A guide, not mandatory
+boilerplate — omit any section with nothing to say. Pairs with `change.yaml` (the
+manifest) and, when the change has more than one independent concern, `areas/<area>.md`
+per `templates/area.md` and `tasks/<n>-<id>.md` per `templates/task.md`.
+
+## Context
+
+Why this change is being considered now.
+
+## Current architecture
+
+Grounded in discovery evidence — current behavior, not aspiration.
+
+## Problem
+
+What the current architecture cannot do, or does poorly.
+
+## Constraints
+
+ADRs, package boundaries, compatibility requirements.
+
+## Affected modules
+
+Packages/projects/docs touched.
+
+## Options and trade-offs
+
+Meaningful architectural approaches considered, with trade-offs. Omit dominated options.
+
+## Owner decisions
+
+Reference `owner-decisions.md` entries.
+
+## Proposed architecture
+
+The approach the owner selected, described precisely enough to decompose into areas and
+tasks.
+
+## Compatibility and migration *(omit if not applicable)*
+
+Breaking changes, migration steps, deprecation path.
+
+## Areas *(omit if the change is not split)*
+
+List of `areas/<area>.md` files and their one-line responsibility.
+
+## Change-wide acceptance criteria
+
+Testable statements that apply across all areas/tasks.
+
+## Verification strategy
+
+How the change as a whole will be verified (build, tests, manual checks).
+
+## ADR impact *(omit if none)*
+
+New ADRs to write, or existing ADRs this change would supersede (owner decision).
+
+## Out of scope
+
+What this change explicitly does not do.

--- a/.claude/skills/nevo-ai-spec-workflow/templates/area.md
+++ b/.claude/skills/nevo-ai-spec-workflow/templates/area.md
@@ -1,0 +1,37 @@
+# Area template
+
+A guide, not mandatory boilerplate. Omit any section with nothing to say. One file per
+independently implementable concern within an Architectural change.
+
+## Responsibility
+
+What this area owns, in one or two sentences.
+
+## Current state
+
+Grounded in discovery evidence.
+
+## Requirements
+
+What this area must do once implemented.
+
+## Constraints
+
+Anything specific to this area beyond the change-wide constraints.
+
+## Interfaces and boundaries
+
+What this area exposes to, and consumes from, other areas or packages.
+
+## Area-specific acceptance criteria
+
+Testable statements scoped to this area.
+
+## Dependencies
+
+Other areas or tasks this one depends on (drives `depends_on` in task front matter).
+
+## Out of scope
+
+What this area explicitly does not cover (especially anything that could be mistaken for
+its responsibility but belongs to another area).

--- a/.claude/skills/nevo-ai-spec-workflow/templates/discovery-report.md
+++ b/.claude/skills/nevo-ai-spec-workflow/templates/discovery-report.md
@@ -1,0 +1,52 @@
+# Discovery report template
+
+A guide, not mandatory boilerplate. Omit any section that has nothing to say — do not
+fill it with "N/A."
+
+## Scope
+
+What question or change prompted this discovery.
+
+## Repository facts
+
+Directly observed facts, each with a file path (and symbol/line where useful).
+
+## Current behavior
+
+What the affected area actually does today, in narrative form, grounded in the facts
+above.
+
+## Evidence
+
+Citations backing the facts and behavior description (file paths, test names).
+
+## Affected areas
+
+Modules/packages/docs likely touched by the change.
+
+## Constraints
+
+Anything that limits the solution space: ADR decisions, package boundaries, compatibility
+requirements.
+
+## Inconsistencies *(omit if none found)*
+
+Places where sources disagree (doc vs. code, example vs. test).
+
+## Open questions
+
+Things that must be answered by the owner — not guessed.
+
+## Options
+
+Meaningful approaches considered, with trade-offs. Omit options that are strictly
+dominated by another.
+
+## Recommendation
+
+One recommended option and why. Explicitly marked as a suggestion, not a decision.
+
+## Owner decisions required
+
+The specific questions that need an explicit answer before a spec can be written, phrased
+so they can be answered directly.

--- a/.claude/skills/nevo-ai-spec-workflow/templates/owner-decisions.md
+++ b/.claude/skills/nevo-ai-spec-workflow/templates/owner-decisions.md
@@ -1,0 +1,20 @@
+# Owner decisions template
+
+A compact, append-only decision record. One entry per material decision — do not create
+an entry for minor local choices (see `references/decision-policy.md`).
+
+```markdown
+## D<n>: <short title>
+
+- **Question:** <the question as posed to the owner>
+- **Options considered:** <option A> | <option B> | ...
+- **Decision:** <what the owner chose>
+- **Rationale:** <owner's reasoning, if given — omit if not provided>
+- **Consequences:** <what this implies for the spec/tasks>
+- **Date:** <YYYY-MM-DD>
+- **Affected artifacts:** <files/tasks this decision constrains>
+```
+
+Do not turn every implementation detail into a `D<n>` entry — only decisions that fall
+under the owner-approval gates in `AGENTS.md`, or that a future reader would otherwise
+have to re-derive from conversation history.

--- a/.claude/skills/nevo-ai-spec-workflow/templates/review-report.md
+++ b/.claude/skills/nevo-ai-spec-workflow/templates/review-report.md
@@ -1,0 +1,45 @@
+# Review report template
+
+A guide, not mandatory boilerplate. Omit any section with nothing to say.
+
+## Verdict
+
+Ready / not ready (spec review) or pass / fail (task review), in one line.
+
+## Blockers
+
+Findings that must be resolved before proceeding. Empty list is a valid, good outcome —
+state it explicitly ("no blockers found") rather than omitting the section.
+
+## Owner decisions required *(omit if none)*
+
+Open questions that block readiness.
+
+## Scope compliance *(task review)*
+
+Whether the diff stayed within `allowed_paths` and away from `forbidden_paths`.
+
+## Acceptance-criteria coverage
+
+Which acceptance criteria are met, which are not, which are untestable as written.
+
+## Architecture compliance
+
+Consistency with `docs/architecture/` and applicable ADRs.
+
+## Tests
+
+Whether behavior changes have corresponding test coverage.
+
+## Documentation
+
+Whether documentation impact was identified and (for task review) actually addressed.
+
+## Risks *(omit if none)*
+
+Non-blocking concerns worth flagging.
+
+## Status recommendation
+
+The task/change status transition recommended — not applied. Owner or explicit
+instruction applies it via `tools/specs.mjs complete`/`verify`/`archive`.

--- a/.claude/skills/nevo-ai-spec-workflow/templates/standard-change.md
+++ b/.claude/skills/nevo-ai-spec-workflow/templates/standard-change.md
@@ -1,0 +1,47 @@
+---
+id: spec.<change-slug>
+type: change
+title: <Title>
+status: draft
+change: <change-slug>
+---
+
+# <Title>
+
+A guide, not mandatory boilerplate. Omit any section with nothing to say.
+
+## Problem
+
+What is wrong or missing today.
+
+## Current behavior
+
+Grounded in discovery evidence, not assumption.
+
+## Desired behavior
+
+What should be true after this change.
+
+## Constraints
+
+ADRs, package boundaries, compatibility requirements that shape the solution.
+
+## Owner decisions
+
+Reference `owner-decisions.md` entries, or inline if there are few.
+
+## Out of scope
+
+What this change explicitly does not do.
+
+## Acceptance criteria
+
+Testable statements — each should be checkable by build, test, or direct inspection.
+
+## Verification
+
+How acceptance criteria will actually be checked (which commands, which tests).
+
+## Documentation impact *(omit if none)*
+
+Which `docs/architecture/` or other documents this change requires updating.

--- a/.claude/skills/nevo-ai-spec-workflow/templates/task.md
+++ b/.claude/skills/nevo-ai-spec-workflow/templates/task.md
@@ -1,0 +1,50 @@
+---
+id: <change-slug>.<task-id>
+status: draft
+change: <change-slug>
+context:
+  required: []
+  optional: []
+allowed_paths:
+  - <glob>
+forbidden_paths:
+  - <glob>
+---
+
+# Task: <Title>
+
+A guide, not mandatory boilerplate. Omit any body section with nothing to say — but keep
+`allowed_paths`/`forbidden_paths` in front matter even when short, since `tools/specs.mjs`
+and the execution policy depend on them being present.
+
+## Goal
+
+What this task accomplishes, precisely enough that `context.required` alone is enough to
+start.
+
+## Dependencies *(omit if none)*
+
+Other task IDs this one's readiness depends on (mirror in front matter `depends_on`).
+
+## Implementation constraints
+
+Anything that shapes *how* this task must be done (patterns to follow, things not to
+introduce) beyond what's already in `allowed_paths`/`forbidden_paths`.
+
+## Acceptance criteria
+
+Testable statements specific to this task.
+
+## Verification
+
+Exact commands/checks that confirm the acceptance criteria (e.g. `dotnet build`,
+`dotnet test`, `node tools/docs.mjs validate`).
+
+## Documentation impact *(omit if none)*
+
+Docs this task must update in the same branch.
+
+## Out of scope
+
+What this task explicitly does not do — especially adjacent work that should be a
+follow-up task instead of scope creep.

--- a/.cursor/rules/nevo.mdc
+++ b/.cursor/rules/nevo.mdc
@@ -27,6 +27,14 @@ of truth for change classes, decision policy, and context loading rules.
 Architecture documentation is in `docs/architecture/`. Do not duplicate it here.
 ADRs are in `docs/adr/`. Development rules are in `docs/development/`.
 
+## Workflow
+
+The full, vendor-neutral specification workflow is `docs/ai/specification-workflow.md`.
+It, together with `tools/specs.mjs` and `tools/docs.mjs`, is the source of truth for how
+changes are discovered, specified, and implemented in this repository. Cursor has no
+namespaced commands of its own here — follow that document and `AGENTS.md` directly
+rather than emulating Claude's `/nevo-ai:*` commands.
+
 ## Git safety
 
 Do not commit, push, or create PRs without explicit owner instruction. Do not use --no-verify.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,13 @@ change classes, decision policy, and context loading rules for this project.
 - New external packages require owner approval
 - Transaction semantics and persistence ownership require owner approval
 
+## Workflow
+
+The full, vendor-neutral specification workflow is `docs/ai/specification-workflow.md`,
+driven by `tools/specs.mjs` and `tools/docs.mjs`. Follow that document and `AGENTS.md`
+directly — this repository does not define Copilot-specific slash commands or prompts;
+those are Claude-specific (`.claude/commands/nevo-ai/`) and should not be copied here.
+
 ## Project stack
 
 - .NET 9, C# with preview features in core projects

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,3 +94,14 @@ specs/archive/         ← completed and abandoned changes (do not load by defau
 
 → See `docs/ai/how-to-navigate.md` for detailed navigation instructions.
 → See `docs/ai/task-execution-policy.md` for task execution rules.
+→ See `docs/ai/specification-workflow.md` for the full, vendor-neutral workflow this
+  file summarizes.
+
+## Tool-specific operational layers
+
+Claude Code users may invoke the namespaced `/nevo-ai:*` commands (`spec-create`,
+`spec-refine`, `spec-review`, `task-next`, `task-start`, `task-review`) — see
+`CLAUDE.md`. Other agents (Cursor, Copilot, or anything else) follow this file and
+`docs/ai/specification-workflow.md` directly, driving `tools/specs.mjs` and
+`tools/docs.mjs` from the terminal. No agent, in any tool, may invent an owner decision
+that these documents require to be asked explicitly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,3 +40,22 @@ dotnet test
 node tools/specs.mjs validate
 node tools/docs.mjs validate
 ```
+
+## `/nevo-ai:*` commands
+
+The shared, vendor-neutral workflow lives in `docs/ai/specification-workflow.md`. Claude
+Code exposes it through namespaced commands (`.claude/commands/nevo-ai/`), backed by the
+shared skill `.claude/skills/nevo-ai-spec-workflow/` and the read-only
+`nevo-ai-spec-researcher` subagent:
+
+| Command | Purpose |
+|---|---|
+| `/nevo-ai:spec-create <change-id> <goal>` | Discover, then create a new specification after owner decisions |
+| `/nevo-ai:spec-refine <change-id> [focus]` | Refine an existing active spec (no implementation) |
+| `/nevo-ai:spec-review <change-id>` | Read-only implementation-readiness review |
+| `/nevo-ai:task-next [filters]` | Return the next approved, ready task |
+| `/nevo-ai:task-start <change-id> <task-id>` | Safely start one task and prepare its context |
+| `/nevo-ai:task-review <change-id> <task-id>` | Review the working tree against one task |
+
+Do not use unqualified `/spec-*` or `/task-*` commands — this repository only defines
+the `nevo-ai` namespace.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,28 @@ This is **.NET Evolution** — build only what matters, and scale when you're re
 | [`NEvo.EntityFramework`](src/NEvo.EntityFramework) | Shared EF infrastructure and base persistence types | ![Persistence](https://img.shields.io/badge/Persistence-brown) | Pre-Alpha |
 | [`NEvo.Orchestrating`](src/NEvo.Orchestrating) | Process orchestration, sagas, and workflow coordination | ![Orchestration](https://img.shields.io/badge/Orchestration-teal) ![Messaging](https://img.shields.io/badge/Messaging-purple) | In progress |
 | [`NEvo.Orchestrating.EntityFramework`](src/NEvo.Orchestrating.EntityFramework) | EF-based persistence for orchestrations | ![Orchestration](https://img.shields.io/badge/Orchestration-teal) ![Persistence](https://img.shields.io/badge/Persistence-brown) | In progress |
+
+---
+
+## Working with AI
+
+This repository uses a human-led, spec-anchored workflow for AI-assisted development —
+the owner makes architectural and scope decisions, agents propose options and implement
+approved work inside a declared context.
+
+- **Start here:** [`AGENTS.md`](AGENTS.md) — portable entry point for any AI agent
+  (change classes, decision policy, context loading rules).
+- **Full workflow:** [`docs/ai/specification-workflow.md`](docs/ai/specification-workflow.md)
+  — vendor-neutral description of discovery, specification, task decomposition, and
+  review.
+- **Tooling:** `node tools/specs.mjs <next|context|start|...>` and
+  `node tools/docs.mjs <validate|find|...>` drive specification and documentation
+  lifecycle deterministically — see the workflow doc for the full command list.
+- **Claude Code:** exposes this workflow through namespaced `/nevo-ai:*` commands
+  (`spec-create`, `spec-refine`, `spec-review`, `task-next`, `task-start`,
+  `task-review`) — see [`CLAUDE.md`](CLAUDE.md).
+- **Cursor / Copilot:** follow `AGENTS.md` and `docs/ai/specification-workflow.md`
+  directly via `.cursor/rules/` and `.github/copilot-instructions.md`.
+
+Specifications live in `specs/active/` (in progress) and `specs/archive/` (completed);
+durable architecture and process decisions live in `docs/architecture/` and `docs/adr/`.

--- a/docs/ai/specification-workflow.md
+++ b/docs/ai/specification-workflow.md
@@ -1,0 +1,200 @@
+---
+id: ai.specification-workflow
+type: ai
+title: NEvo specification workflow
+status: current
+read_when:
+  - starting a new change
+  - deciding how much specification a change needs
+  - unsure whether a decision needs owner approval
+summary: >
+  Vendor-neutral description of NEvo's human-led, spec-anchored development process:
+  how changes are classified, discovered, specified, decomposed into tasks, and
+  implemented, and how tools/docs.mjs and tools/specs.mjs enforce it.
+related:
+  - ai.how-to-navigate
+  - ai.task-execution-policy
+  - adr.0002-lightweight-markdown-workflow
+---
+
+# NEvo specification workflow
+
+This document is the single vendor-neutral source of truth for how AI agents plan and
+execute changes in this repository. It applies equally to Claude Code, Cursor, GitHub
+Copilot, and any other tool. Tool-specific adapters (`CLAUDE.md`, `.cursor/rules/`,
+`.github/copilot-instructions.md`, and Claude's `/nevo-ai:*` commands) point here instead
+of duplicating it.
+
+The process itself — and the decision to build a lightweight custom workflow instead of
+adopting an external framework — is recorded in
+[ADR-0002](../adr/ADR-0002-lightweight-markdown-workflow.md).
+
+## Principles
+
+1. **Human-led.** The repository owner makes architectural and scope decisions. Agents
+   propose options and a recommendation; they do not decide on the owner's behalf.
+2. **Spec-anchored.** Non-trivial work is described in a specification before it is
+   implemented. Agents load only the context a task declares as required, not the whole
+   repository.
+3. **Separation of specification and implementation.** Writing or refining a spec never
+   implies starting implementation, and vice versa. Each is a distinct, explicit step.
+4. **Deterministic where possible.** Status transitions, branch creation, and index
+   generation go through `tools/specs.mjs` and `tools/docs.mjs`, not natural-language
+   guesses.
+
+## Change classification
+
+Every change is classified before any artifact is created. See `AGENTS.md` for the
+authoritative table; in summary:
+
+| Class | Spec required |
+|---|---|
+| **S — Small** | None |
+| **T — Standard** | `specs/active/<slug>/spec.md` (or an equivalent single-file spec) |
+| **A — Architectural** | Full change directory: `change.yaml`, `overview.md`, optional `areas/`, `tasks/` |
+| **E — Exploratory** | `specs/active/<slug>/discovery.md`, owner decides the next class |
+
+When in doubt between two classes, prefer the smaller one and let refinement upgrade it
+if the owner's decisions turn out to require more structure.
+
+## Discovery before specification
+
+Before proposing a specification, an agent must ground itself in the current repository
+state:
+
+- current behavior of the affected area (code, tests, examples),
+- existing documentation (`docs/architecture/`, `docs/development/`, `docs/adr/`),
+- whether an active or archived change already covers the same ground,
+- constraints implied by accepted ADRs.
+
+Broad, read-only exploration that would otherwise crowd the main context should be
+delegated to a read-only research subagent (in Claude Code: `nevo-ai-spec-researcher`).
+The researcher returns facts and evidence, not architecture decisions.
+
+Discovery output separates:
+- **facts** — directly observed in code or docs,
+- **inferences** — reasonable conclusions drawn from facts,
+- **inconsistencies** — places where sources disagree,
+- **open questions** — things that must be asked, not guessed.
+
+## Owner approval gates
+
+Some decisions may never be inferred by an agent. The authoritative list lives in
+`AGENTS.md` under "Decision policy" (public API shape, package dependency direction, new
+external dependencies, transaction semantics, persistence ownership, message processing
+behavior changes, breaking changes, compatibility decisions, new packages/projects,
+CI/CD changes). When a change touches one of these, the agent presents options and a
+recommendation, then stops and waits — it does not proceed on an assumed answer.
+
+## Artifact decomposition
+
+A specification should be no larger than it needs to be:
+
+- A **Standard** change is a single spec file.
+- An **Architectural** change splits into `areas/` when it has more than one
+  independently implementable concern, so that each area (and each task inside it) can
+  carry its own, smaller context packet.
+- Do not create empty template sections or files "for completeness." Every artifact
+  earns its place by reducing ambiguity or context size for the agent that implements it.
+
+## Task context packets
+
+Every implementable task carries `context.required`, `context.optional`,
+`allowed_paths`, and `forbidden_paths` in its front matter. `tools/specs.mjs context
+<change> <task>` resolves this into a JSON packet. Agents load `required` context before
+touching code, load `optional` only if the task text references it, and treat
+`allowed_paths`/`forbidden_paths` as a hard scope boundary — not a suggestion. This is
+what keeps large specifications from forcing every task to read the entire change.
+
+## Using `tools/specs.mjs`
+
+```
+node tools/specs.mjs generate                  # rebuild specs/*.generated.*
+node tools/specs.mjs validate                  # validate all change manifests
+node tools/specs.mjs check                     # validate + verify indexes are current
+node tools/specs.mjs list                      # list active changes and task statuses
+node tools/specs.mjs next                      # next approved, dependency-ready task → JSON
+node tools/specs.mjs context <change> <task>   # context packet for one task → JSON
+node tools/specs.mjs start <change> <task>     # create/switch branch, set task in-implementation
+node tools/specs.mjs complete <change> <task>  # mark task implemented
+node tools/specs.mjs verify <change> <task>    # mark task verified (owner-reviewed)
+node tools/specs.mjs archive <change>          # move a fully terminal change to specs/archive/
+```
+
+`start` refuses to run on a dirty working tree. `next` only ever returns a task whose
+status is `approved` and whose dependencies are all in a terminal status
+(`implemented`, `verified`, `archived`, `abandoned`) — task selection is never a manual
+scan of spec files.
+
+## Using `tools/docs.mjs`
+
+```
+node tools/docs.mjs generate                          # rebuild docs/index.generated.*
+node tools/docs.mjs validate                           # validate front matter across docs/
+node tools/docs.mjs check                               # validate + verify index is current
+node tools/docs.mjs find --scope <scope> [--type <type>] [--format json]
+```
+
+`docs.mjs` only scans `docs/`. Every document type (`architecture`, `development`,
+`adr`, `ai`, `change`) has required front-matter fields enforced by `validate` — see
+`tools/docs.mjs` for the exact list per type. `.claude/**` files are intentionally
+outside this index: they are Claude-specific adapters, not shared documentation.
+
+## Specification and implementation are separate steps
+
+Producing or refining a specification never authorizes implementation. A specification
+is "ready for implementation" only once:
+
+- every task the owner intends to start next has `status: approved`,
+- `depends_on` references are satisfied or clearly sequenced,
+- `allowed_paths`/`forbidden_paths` are present and unambiguous,
+- acceptance criteria are testable, not aspirational,
+- `node tools/specs.mjs validate` (and `docs.mjs validate`, if docs changed) passes.
+
+Implementation then proceeds task by task via `tools/specs.mjs start`, never by an agent
+inferring that "the spec looks done."
+
+## Architecture documentation and ADRs
+
+`docs/architecture/` describes **current** behavior, not desired future state.
+Experimental or incomplete modules must be marked as such rather than presented as
+stable. A specification that changes durable architectural decisions must say so
+explicitly and call out the ADR(s) it affects; new durable decisions are recorded as new
+ADRs in `docs/adr/` (see `ADR-0001` for the commit-message convention this repository
+follows, and `ADR-0002` for the workflow itself). Superseding an ADR is an owner
+decision, not an inference.
+
+## Active versus archived specifications
+
+`specs/active/` holds every change currently being discovered, specified, or
+implemented. `specs/archive/` holds changes whose tasks are all in a terminal status.
+Archived specs are not loaded by default — only when a task explicitly references one,
+when historical reasoning is requested, or when an ADR or active spec requires it. Never
+start a task from `specs/archive/`.
+
+## Git safety
+
+- No commit, push, or pull request without explicit owner instruction.
+- Never `--no-verify`, never force-push.
+- No drive-by refactoring outside a task's `allowed_paths`.
+- Branches are created via `tools/specs.mjs start`, not by hand, except where an agent
+  has been explicitly authorized to create one outside the specs lifecycle.
+- Show the diff and verification results before asking to commit.
+
+Full detail: `docs/development/git-workflow.md` and `docs/development/commit-conventions.md`.
+
+## Tool adapters
+
+This document is the shared policy. Tool-specific layers are thin:
+
+- **Claude Code** exposes `/nevo-ai:spec-create`, `/nevo-ai:spec-refine`,
+  `/nevo-ai:spec-review`, `/nevo-ai:task-next`, `/nevo-ai:task-start`, and
+  `/nevo-ai:task-review` (see `.claude/commands/nevo-ai/`), backed by the shared skill
+  `.claude/skills/nevo-ai-spec-workflow/`. These commands call the same
+  `tools/specs.mjs` / `tools/docs.mjs` CLIs described above — they do not implement a
+  parallel workflow.
+- **Cursor** and **Copilot** have no namespaced commands. They follow this document and
+  `AGENTS.md` directly, driving `tools/specs.mjs` / `tools/docs.mjs` from the terminal.
+
+No agent — regardless of tool — may invent an owner decision that this document requires
+to be asked explicitly.

--- a/docs/index.generated.json
+++ b/docs/index.generated.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-01T13:48:09.972Z",
+  "generated": "2026-08-01T15:02:47.173Z",
   "docs": [
     {
       "file": "docs/architecture/event-sourcing.md",
@@ -309,6 +309,24 @@
       "summary": "Step-by-step guide for agents to find the right context for a task. Always start with the specs CLI, not by scanning all files.",
       "related": [
         "ai.task-execution-policy"
+      ]
+    },
+    {
+      "file": "docs/ai/specification-workflow.md",
+      "id": "ai.specification-workflow",
+      "type": "ai",
+      "title": "NEvo specification workflow",
+      "status": "current",
+      "read_when": [
+        "starting a new change",
+        "deciding how much specification a change needs",
+        "unsure whether a decision needs owner approval"
+      ],
+      "summary": "Vendor-neutral description of NEvo's human-led, spec-anchored development process: how changes are classified, discovered, specified, decomposed into tasks, and implemented, and how tools/docs.mjs and tools/specs.mjs enforce it.",
+      "related": [
+        "ai.how-to-navigate",
+        "ai.task-execution-policy",
+        "adr.0002-lightweight-markdown-workflow"
       ]
     },
     {

--- a/docs/index.generated.md
+++ b/docs/index.generated.md
@@ -2,43 +2,44 @@
 
 # Documentation index
 
-_Generated: 2026-08-01T13:48:09.973Z_
+_Generated: 2026-08-01T15:02:47.174Z_
 
 ## Architecture
 
 | ID | Title | Status | Scopes |
 |---|---|---|---|
-| `architecture.event-sourcing` | [Event sourcing](docs/architecture/event-sourcing.md) | experimental | event-sourcing, aggregates, ddd |
-| `architecture.inbox-outbox` | [Inbox and outbox](docs/architecture/inbox-outbox.md) | current | messaging, inbox, outbox, idempotency |
-| `architecture.message-context` | [Message context](docs/architecture/message-context.md) | current | messaging, context, correlation |
-| `architecture.messaging-pipeline` | [Messaging pipeline](docs/architecture/messaging-pipeline.md) | current | messaging, middleware, handlers, dispatch |
-| `architecture.orchestration` | [Orchestration](docs/architecture/orchestration.md) | experimental | orchestration, sagas |
-| `architecture.overview` | [NEvo architecture overview](docs/architecture/overview.md) | current | overview, modules, philosophy |
-| `architecture.package-boundaries` | [Package boundaries](docs/architecture/package-boundaries.md) | current | packages, dependencies, modularity |
-| `architecture.persistence` | [Persistence](docs/architecture/persistence.md) | current | persistence, entity-framework, transactions |
-| `architecture.processing-model` | [Processing model](docs/architecture/processing-model.md) | current | messaging, strategies, handlers |
+| `architecture.event-sourcing` | [Event sourcing](architecture/event-sourcing.md) | experimental | event-sourcing, aggregates, ddd |
+| `architecture.inbox-outbox` | [Inbox and outbox](architecture/inbox-outbox.md) | current | messaging, inbox, outbox, idempotency |
+| `architecture.message-context` | [Message context](architecture/message-context.md) | current | messaging, context, correlation |
+| `architecture.messaging-pipeline` | [Messaging pipeline](architecture/messaging-pipeline.md) | current | messaging, middleware, handlers, dispatch |
+| `architecture.orchestration` | [Orchestration](architecture/orchestration.md) | experimental | orchestration, sagas |
+| `architecture.overview` | [NEvo architecture overview](architecture/overview.md) | current | overview, modules, philosophy |
+| `architecture.package-boundaries` | [Package boundaries](architecture/package-boundaries.md) | current | packages, dependencies, modularity |
+| `architecture.persistence` | [Persistence](architecture/persistence.md) | current | persistence, entity-framework, transactions |
+| `architecture.processing-model` | [Processing model](architecture/processing-model.md) | current | messaging, strategies, handlers |
 
 ## Development
 
 | ID | Title | Status | Scopes |
 |---|---|---|---|
-| `development.commit-conventions` | [Commit conventions](docs/development/commit-conventions.md) | current |  |
-| `development.git-workflow` | [Git workflow](docs/development/git-workflow.md) | current |  |
-| `development.local-setup` | [Local setup](docs/development/local-setup.md) | current |  |
-| `development.pull-requests` | [Pull requests](docs/development/pull-requests.md) | current |  |
-| `development.testing` | [Testing](docs/development/testing.md) | current |  |
+| `development.commit-conventions` | [Commit conventions](development/commit-conventions.md) | current |  |
+| `development.git-workflow` | [Git workflow](development/git-workflow.md) | current |  |
+| `development.local-setup` | [Local setup](development/local-setup.md) | current |  |
+| `development.pull-requests` | [Pull requests](development/pull-requests.md) | current |  |
+| `development.testing` | [Testing](development/testing.md) | current |  |
 
 ## Adr
 
 | ID | Title | Status | Scopes |
 |---|---|---|---|
-| `adr.0001-conventional-commits` | [Adopt Conventional Commits](docs/adr/ADR-0001-conventional-commits.md) | accepted |  |
-| `adr.0002-lightweight-markdown-workflow` | [Use lightweight custom Markdown workflow for AI-assisted SDLC](docs/adr/ADR-0002-lightweight-markdown-workflow.md) | accepted |  |
+| `adr.0001-conventional-commits` | [Adopt Conventional Commits](adr/ADR-0001-conventional-commits.md) | accepted |  |
+| `adr.0002-lightweight-markdown-workflow` | [Use lightweight custom Markdown workflow for AI-assisted SDLC](adr/ADR-0002-lightweight-markdown-workflow.md) | accepted |  |
 
 ## Ai
 
 | ID | Title | Status | Scopes |
 |---|---|---|---|
-| `ai.how-to-navigate` | [How to navigate NEvo artifacts](docs/ai/how-to-navigate.md) | current |  |
-| `ai.task-execution-policy` | [Task execution policy](docs/ai/task-execution-policy.md) | current |  |
+| `ai.how-to-navigate` | [How to navigate NEvo artifacts](ai/how-to-navigate.md) | current |  |
+| `ai.specification-workflow` | [NEvo specification workflow](ai/specification-workflow.md) | current |  |
+| `ai.task-execution-policy` | [Task execution policy](ai/task-execution-policy.md) | current |  |
 

--- a/specs/active.generated.md
+++ b/specs/active.generated.md
@@ -5,3 +5,4 @@
 | ID | Title | Status | Priority | Created |
 |---|---|---|---|---|
 | `architecture-documentation` | Architecture documentation | in-implementation | 10 | 2026-08-01 |
+| `nevo-ai-operational-workflow` | NEvo AI operational workflow (Claude Code layer) | in-implementation | 10 | 2026-08-01 |

--- a/specs/active/nevo-ai-operational-workflow/change.yaml
+++ b/specs/active/nevo-ai-operational-workflow/change.yaml
@@ -1,0 +1,16 @@
+id: nevo-ai-operational-workflow
+title: NEvo AI operational workflow (Claude Code layer)
+type: architectural
+status: in-implementation
+priority: 10
+created: 2026-08-01
+
+branch:
+  mode: per-change
+  prefix: feature
+
+tasks:
+  - id: add-operational-layer
+    order: 1
+    file: tasks/01-add-operational-layer.md
+    status: implemented

--- a/specs/active/nevo-ai-operational-workflow/overview.md
+++ b/specs/active/nevo-ai-operational-workflow/overview.md
@@ -1,0 +1,75 @@
+---
+id: spec.nevo-ai-operational-workflow
+type: change
+title: NEvo AI operational workflow (Claude Code layer)
+status: in-implementation
+change: nevo-ai-operational-workflow
+---
+
+# NEvo AI operational workflow (Claude Code layer)
+
+## Goal
+
+Add a Claude Code operational layer on top of the AI-assisted SDLC process bootstrapped
+in `architecture-documentation`: namespaced `/nevo-ai:*` commands, a shared workflow
+skill, and a read-only research subagent — without replacing `AGENTS.md`,
+`tools/specs.mjs`, or `tools/docs.mjs`. Consolidate the vendor-neutral workflow
+description into `docs/ai/specification-workflow.md` so Claude, Cursor, and Copilot
+adapters can point to one source instead of duplicating it.
+
+This change was authorized in full by an owner-provided instruction document
+(`01-add-nevo-ai-operational-workflow.md`), which pre-approved the file structure,
+responsibilities, and safety constraints below — see "Owner decisions" for what remained
+open.
+
+## Acceptance criteria
+
+- Every new user-facing Claude command is namespaced `/nevo-ai:*`; no unqualified
+  `/spec-*` or `/task-*` command exists.
+- `docs/ai/specification-workflow.md` exists, is vendor-neutral, and passes
+  `node tools/docs.mjs validate`.
+- `.claude/skills/nevo-ai-spec-workflow/` exists with a concise `SKILL.md` (under 500
+  lines) plus `references/` and `templates/` — detailed policy lives in `references/`,
+  not inline in the skill or in every command.
+- `.claude/agents/nevo-ai-spec-researcher.md` exists, is read-only, and cannot edit
+  files, create specs, choose architecture, change task status, or create
+  branches/commits.
+- `.claude/commands/nevo-ai/` contains `spec-create`, `spec-refine`, `spec-review`,
+  `task-next`, `task-start`, `task-review` — each a thin adapter that calls
+  `tools/specs.mjs` / `tools/docs.mjs` for deterministic operations rather than
+  reimplementing them.
+- `AGENTS.md`, `CLAUDE.md`, `.cursor/rules/nevo.mdc`, and
+  `.github/copilot-instructions.md` gain only short navigation references to the shared
+  workflow doc — no full workflow duplicated into any adapter.
+- `README.md` gains a short "Working with AI" section pointing to `AGENTS.md` and
+  `docs/ai/specification-workflow.md` (owner-requested during this change, see Owner
+  decisions).
+- `node tools/docs.mjs validate` and `node tools/specs.mjs validate` pass.
+- No file under `src/**`, `tests/**`, `examples/**`, `*.csproj`, `*.sln`,
+  `Directory.Build.props`, `Directory.Packages.props`, `global.json`, or
+  `.github/workflows/**` is modified.
+- No commit, push, or pull request is created without explicit owner instruction.
+
+## Owner decisions
+
+- **Branch:** owner instructed starting this work on a new branch
+  (`feature/nevo-ai-operational-workflow`) rather than reusing the already-merged
+  `feature/ai-sdlc-bootstrap`.
+- **Spec for consistency:** owner explicitly authorized recording this change as a spec
+  under `specs/active/` "for consistency with the work being done," even though the
+  instruction document that authorized the implementation was supplied outside the
+  normal `/nevo-ai:spec-create` flow.
+- **README section:** owner separately requested a "Working with AI" section in
+  `README.md` describing how AI-assisted work happens in this repository — added to
+  scope for this change rather than filed as a separate one, since it is a small,
+  purely-additive documentation change directly about this same workflow.
+
+## Out of scope
+
+- Any change to `tools/specs.mjs` or `tools/docs.mjs` *behavior* (schema, status
+  transitions, CLI commands) — only documentation/help-text-level changes were
+  permitted, and none were needed.
+- Any change to the specification/document schema, valid status transitions, or branch
+  naming rules.
+- A Claude Code plugin — this is project-local commands/skills/agents only.
+- Modifying source code, tests, examples, build configuration, or CI.

--- a/specs/active/nevo-ai-operational-workflow/tasks/01-add-operational-layer.md
+++ b/specs/active/nevo-ai-operational-workflow/tasks/01-add-operational-layer.md
@@ -1,0 +1,61 @@
+---
+id: nevo-ai-operational-workflow.add-operational-layer
+status: implemented
+change: nevo-ai-operational-workflow
+context:
+  required: []
+  optional:
+    - ../../../AGENTS.md
+    - ../../../docs/adr/ADR-0002-lightweight-markdown-workflow.md
+allowed_paths:
+  - .claude/**
+  - docs/ai/**
+  - AGENTS.md
+  - CLAUDE.md
+  - .cursor/**
+  - .github/copilot-instructions.md
+  - README.md
+  - specs/active/**
+  - specs/archive/**
+  - tools/**
+  - docs/index.generated.*
+  - specs/*.generated.*
+forbidden_paths:
+  - src/**
+  - tests/**
+  - examples/**
+  - "*.csproj"
+  - "*.sln"
+  - Directory.Build.props
+  - Directory.Packages.props
+  - global.json
+  - .github/workflows/**
+---
+
+# Task: Add the nevo-ai operational layer
+
+## Goal
+
+Create the `.claude/commands/nevo-ai/`, `.claude/skills/nevo-ai-spec-workflow/`, and
+`.claude/agents/nevo-ai-spec-researcher.md` structure; create
+`docs/ai/specification-workflow.md`; update navigation references in `AGENTS.md`,
+`CLAUDE.md`, `.cursor/rules/nevo.mdc`, and `.github/copilot-instructions.md`; add a
+"Working with AI" section to `README.md`.
+
+## Acceptance criteria
+
+- All files listed in the change overview's acceptance criteria exist with the required
+  content and structure.
+- `node tools/docs.mjs validate` reports no errors.
+- `node tools/specs.mjs validate` reports no errors for this change.
+- `tools/docs.mjs generate` / `tools/specs.mjs generate` produce valid generated
+  indexes reflecting the new documents and this spec.
+- No file outside `allowed_paths` is touched.
+
+## Out of scope
+
+- Modifying any `.csproj`, `.sln`, build-config, or source file.
+- Modifying `tools/specs.mjs` / `tools/docs.mjs` behavior.
+- Creating a Claude Code plugin.
+- Committing, pushing, or opening a pull request as part of this task's own execution —
+  those happen as an explicit, separate step once the owner has reviewed the diff.

--- a/specs/index.generated.json
+++ b/specs/index.generated.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-01T13:48:10.089Z",
+  "generated": "2026-08-01T15:02:47.285Z",
   "changes": [
     {
       "id": "architecture-documentation",
@@ -12,6 +12,21 @@
           "id": "core-architecture-docs",
           "order": 1,
           "file": "tasks/01-core-architecture-docs.md",
+          "status": "implemented"
+        }
+      ]
+    },
+    {
+      "id": "nevo-ai-operational-workflow",
+      "title": "NEvo AI operational workflow (Claude Code layer)",
+      "status": "in-implementation",
+      "priority": 10,
+      "created": "2026-08-01",
+      "tasks": [
+        {
+          "id": "add-operational-layer",
+          "order": 1,
+          "file": "tasks/01-add-operational-layer.md",
           "status": "implemented"
         }
       ]


### PR DESCRIPTION
Add namespaced /nevo-ai:* commands, a shared nevo-ai-spec-workflow skill, and a read-only nevo-ai-spec-researcher subagent on top of the existing AI-assisted SDLC process, so Claude Code can drive specs.mjs/docs.mjs through discovery, specification, task decomposition, and review without duplicating that policy into every command.

- docs/ai/specification-workflow.md: vendor-neutral workflow doc shared by Claude, Cursor, and Copilot adapters
- .claude/skills/nevo-ai-spec-workflow/: concise skill + references/ + templates/, loaded per phase rather than all at once
- .claude/agents/nevo-ai-spec-researcher.md: read-only discovery subagent
- .claude/commands/nevo-ai/: spec-create, spec-refine, spec-review, task-next, task-start, task-review
- AGENTS.md, CLAUDE.md, .cursor/rules/nevo.mdc, .github/copilot-instructions.md: thin navigation updates only
- README.md: new "Working with AI" section pointing to the workflow docs
- specs/active/nevo-ai-operational-workflow/: this change tracked as a spec for consistency with other tracked work

No src/tests/examples/build-config files touched; no push or PR created.

## Summary

<!-- What does this PR do and why? -->

## Related artifacts

- Spec: <!-- specs/active/<slug>/ or "none (Class S)" -->
- Task: <!-- specs/active/<slug>/tasks/<task>.md or "n/a" -->
- ADR: <!-- docs/adr/ADR-XXXX-*.md or "none" -->

## Changes

<!-- What was changed? Keep it to a few bullet points. -->

## Verification

<!-- How was this verified? Tests run, manual steps, etc. -->

## Documentation impact

<!-- Were docs/architecture/ or docs/development/ updated? If not, why not? -->

## Breaking changes

<!-- none / describe the behavior change -->

## Follow-ups

<!-- Anything deferred? Link to follow-up spec or issue. -->
