### PR TITLE
feat(dashboard): add shared color design tokens (COLOR-1)

### DIFF
--- a/specs/active/ux-improvements-version-1/change.yaml
+++ b/specs/active/ux-improvements-version-1/change.yaml
@@ -14,7 +14,9 @@ tasks:
   - id: design-tokens
     order: 1
     file: tasks/01-design-tokens.md
-    status: approved
+    status: in-implementation
+    implementation:
+      baseline_revision: aa17c86bd89326a3475d0d07e42b54df1779ccee
 
   - id: composer-alignment
     order: 2

--- a/tools/dashboard/src/components/ai-session-list.tsx
+++ b/tools/dashboard/src/components/ai-session-list.tsx
@@ -51,20 +51,20 @@ export function ProviderBadge({ provider }: { provider: string }) {
   const norm = provider.toLowerCase();
   if (norm.includes('claude')) {
     return (
-      <span className="inline-flex items-center gap-1 rounded-md bg-amber-500/10 px-1.5 py-0.5 font-medium text-amber-300">
+      <span className="inline-flex items-center gap-1 rounded-md bg-[color-mix(in_srgb,var(--cat-1)_10%,transparent)] px-1.5 py-0.5 font-medium text-[var(--cat-1)]">
         <Sparkles className="size-3" /> Claude
       </span>
     );
   }
   if (norm.includes('antigravity')) {
     return (
-      <span className="inline-flex items-center gap-1 rounded-md bg-purple-500/10 px-1.5 py-0.5 font-medium text-purple-300">
+      <span className="inline-flex items-center gap-1 rounded-md bg-[color-mix(in_srgb,var(--cat-2)_10%,transparent)] px-1.5 py-0.5 font-medium text-[var(--cat-2)]">
         <Cpu className="size-3" /> Antigravity
       </span>
     );
   }
   return (
-    <span className="inline-flex items-center gap-1 rounded-md bg-emerald-500/10 px-1.5 py-0.5 font-medium text-emerald-300">
+    <span className="inline-flex items-center gap-1 rounded-md bg-[var(--surface)] px-1.5 py-0.5 font-medium text-[var(--muted-strong)]">
       <Bot className="size-3" /> {provider}
     </span>
   );

--- a/tools/dashboard/src/components/ai-session-list.tsx
+++ b/tools/dashboard/src/components/ai-session-list.tsx
@@ -167,7 +167,7 @@ export function AiSessionRow({
             }
           }}
           disabled={isDeleting}
-          className="absolute right-2.5 top-2.5 flex size-6 items-center justify-center rounded-lg text-[var(--muted)] opacity-70 transition-all hover:bg-red-500/15 hover:text-red-400 hover:opacity-100 focus:opacity-100 disabled:opacity-30"
+          className="absolute right-2.5 top-2.5 flex size-6 items-center justify-center rounded-lg text-[var(--muted)] opacity-70 transition-all hover:bg-[color-mix(in_srgb,var(--danger)_15%,transparent)] hover:text-[var(--danger)] hover:opacity-100 focus:opacity-100 disabled:opacity-30"
         >
           {isDeleting ? <LoaderCircle className="size-3.5 animate-spin" /> : <Trash2 className="size-3.5" />}
         </button>

--- a/tools/dashboard/src/components/ai-tool-view.tsx
+++ b/tools/dashboard/src/components/ai-tool-view.tsx
@@ -37,8 +37,8 @@ export function AiToolView({ toolCall }: AiToolViewProps) {
           <span
             className={cn(
               'rounded-full px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wider',
-              isRunning && 'bg-amber-400/10 text-amber-300',
-              isCompleted && 'bg-emerald-400/10 text-emerald-300',
+              isRunning && 'bg-[color-mix(in_srgb,var(--info)_10%,transparent)] text-[var(--info)]',
+              isCompleted && 'bg-[color-mix(in_srgb,var(--success)_10%,transparent)] text-[var(--success-strong)]',
               isFailed && 'bg-red-400/10 text-red-300'
             )}
           >
@@ -48,7 +48,7 @@ export function AiToolView({ toolCall }: AiToolViewProps) {
 
         <div className="flex items-center gap-2 shrink-0 text-[var(--muted)]">
           {isRunning && <LoaderCircle className="size-3.5 animate-spin text-[var(--accent)]" />}
-          {isCompleted && <CheckCircle2 className="size-3.5 text-emerald-400" />}
+          {isCompleted && <CheckCircle2 className="size-3.5 text-[var(--success)]" />}
           {isFailed && <XCircle className="size-3.5 text-red-400" />}
           {toolCall.durationMs != null && (
             <span className="flex items-center gap-1 text-[10px]">

--- a/tools/dashboard/src/components/ai-tool-view.tsx
+++ b/tools/dashboard/src/components/ai-tool-view.tsx
@@ -39,7 +39,7 @@ export function AiToolView({ toolCall }: AiToolViewProps) {
               'rounded-full px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wider',
               isRunning && 'bg-[color-mix(in_srgb,var(--info)_10%,transparent)] text-[var(--info)]',
               isCompleted && 'bg-[color-mix(in_srgb,var(--success)_10%,transparent)] text-[var(--success-strong)]',
-              isFailed && 'bg-red-400/10 text-red-300'
+              isFailed && 'bg-[color-mix(in_srgb,var(--danger)_10%,transparent)] text-[var(--danger-strong)]'
             )}
           >
             {toolCall.status}
@@ -49,7 +49,7 @@ export function AiToolView({ toolCall }: AiToolViewProps) {
         <div className="flex items-center gap-2 shrink-0 text-[var(--muted)]">
           {isRunning && <LoaderCircle className="size-3.5 animate-spin text-[var(--accent)]" />}
           {isCompleted && <CheckCircle2 className="size-3.5 text-[var(--success)]" />}
-          {isFailed && <XCircle className="size-3.5 text-red-400" />}
+          {isFailed && <XCircle className="size-3.5 text-[var(--danger)]" />}
           {toolCall.durationMs != null && (
             <span className="flex items-center gap-1 text-[10px]">
               <Clock className="size-3" />

--- a/tools/dashboard/src/components/changes-panel.tsx
+++ b/tools/dashboard/src/components/changes-panel.tsx
@@ -163,7 +163,7 @@ function FileChange({
 
       {open && (
         diffItem.isError ? (
-          <div className="border-t border-[var(--border)] px-4 py-7 text-center text-xs text-red-300">
+          <div className="border-t border-[var(--border)] px-4 py-7 text-center text-xs text-[var(--danger-strong)]">
             {diffItem.error?.message || 'Nie udało się wczytać diffu dla tego pliku.'}
           </div>
         ) : diff === undefined ? (
@@ -439,7 +439,7 @@ function PullRequestCard({ change, pullRequest, mode }: { change: DashboardChang
               <LoaderCircle className="size-3.5 animate-spin text-[var(--accent)]" /> Wczytywanie listy plików…
             </div>
           ) : filesQuery.error ? (
-            <div className="rounded-xl border border-red-400/20 px-5 py-10 text-center text-xs text-red-300">
+            <div className="rounded-xl border border-[color-mix(in_srgb,var(--danger)_20%,transparent)] px-5 py-10 text-center text-xs text-[var(--danger-strong)]">
               {filesQuery.error}
             </div>
           ) : groups.length ? (
@@ -537,7 +537,7 @@ function PullRequestCard({ change, pullRequest, mode }: { change: DashboardChang
                 <LoaderCircle className="size-3.5 animate-spin text-[var(--accent)]" /> Wczytywanie pełnego diffu…
               </div>
             ) : fullDiffQuery.error ? (
-              <div className="border-t border-[var(--border)] px-4 py-6 text-xs text-red-300">{fullDiffQuery.error}</div>
+              <div className="border-t border-[var(--border)] px-4 py-6 text-xs text-[var(--danger-strong)]">{fullDiffQuery.error}</div>
             ) : fullDiffQuery.data ? (
               <pre className="max-h-[70vh] overflow-auto border-t border-[var(--border)] p-4 font-mono text-[11px] leading-5 text-[var(--muted-strong)]">
                 {fullDiffQuery.data.diffAvailable ? fullDiffQuery.data.diff : 'Provider nie zwrócił pełnego diffu.'}

--- a/tools/dashboard/src/components/changes-panel.tsx
+++ b/tools/dashboard/src/components/changes-panel.tsx
@@ -61,7 +61,7 @@ function stateLabel(pullRequest: AvailablePullRequest) {
 }
 
 function stateTone(pullRequest: AvailablePullRequest) {
-  if (pullRequest.draft) return 'border-slate-400/20 bg-slate-400/8 text-slate-300';
+  if (pullRequest.draft) return 'border-[color-mix(in_srgb,var(--muted)_20%,transparent)] bg-[color-mix(in_srgb,var(--muted)_8%,transparent)] text-[var(--muted-strong)]';
   if (pullRequest.state === 'merged') return 'border-violet-400/25 bg-violet-400/10 text-violet-300';
   if (pullRequest.state === 'closed') return 'border-red-400/20 bg-red-400/8 text-red-300';
   return 'border-[color-mix(in_srgb,var(--accent)_25%,transparent)] bg-[color-mix(in_srgb,var(--accent)_8%,transparent)] text-[var(--accent)]';
@@ -226,7 +226,7 @@ function IncompleteDiffIndicator({
   if (!incomplete) return null;
 
   return (
-    <div className="mb-4 flex items-start gap-2 rounded-lg border border-amber-300/15 bg-amber-300/6 px-3 py-2.5 text-[10px] leading-5 text-amber-100/80">
+    <div className="mb-4 flex items-start gap-2 rounded-lg border border-[color-mix(in_srgb,var(--warning)_15%,transparent)] bg-[color-mix(in_srgb,var(--warning)_6%,transparent)] px-3 py-2.5 text-[10px] leading-5 text-[color-mix(in_srgb,var(--warning)_80%,transparent)]">
       <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
       Część diffu może być niedostępna lub skrócona przez providera. Lista plików i statystyki pozostają widoczne.
     </div>
@@ -594,9 +594,9 @@ function PullRequestSummaryCard({
 
 function UnavailableCard({ result }: { result: UnavailablePullRequest }) {
   return (
-    <Card className="border-amber-300/15 p-5 sm:p-6">
+    <Card className="border-[color-mix(in_srgb,var(--warning)_15%,transparent)] p-5 sm:p-6">
       <div className="flex items-start gap-3">
-        <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-amber-300/15 bg-amber-300/6 text-amber-200">
+        <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-[color-mix(in_srgb,var(--warning)_15%,transparent)] bg-[color-mix(in_srgb,var(--warning)_6%,transparent)] text-[var(--warning)]">
           <AlertTriangle className="size-4" />
         </div>
         <div>

--- a/tools/dashboard/src/components/operation-progress.tsx
+++ b/tools/dashboard/src/components/operation-progress.tsx
@@ -19,14 +19,14 @@ import { cn } from '@/lib/utils';
 export function StepStatusIcon({ status }: { status: OperationStepStatus }) {
   switch (status) {
     case 'completed':
-      return <CheckCircle2 className="size-4 text-emerald-400 shrink-0" />;
+      return <CheckCircle2 className="size-4 text-[var(--success)] shrink-0" />;
     case 'running':
-      return <LoaderCircle className="size-4 text-sky-400 animate-spin shrink-0" />;
+      return <LoaderCircle className="size-4 text-[var(--info)] animate-spin shrink-0" />;
     case 'failed':
-      return <AlertCircle className="size-4 text-rose-400 shrink-0" />;
+      return <AlertCircle className="size-4 text-[var(--danger)] shrink-0" />;
     case 'pending':
     default:
-      return <Circle className="size-3.5 text-zinc-500 shrink-0 opacity-50" />;
+      return <Circle className="size-3.5 text-[var(--muted)] shrink-0 opacity-50" />;
   }
 }
 
@@ -35,8 +35,8 @@ export function OperationStepRow({ step }: { step: OperationStep }) {
     <li
       className={cn(
         'flex items-start gap-3 rounded-lg px-3 py-2.5 transition-colors text-xs',
-        step.status === 'running' && 'bg-sky-500/10 border border-sky-500/20',
-        step.status === 'failed' && 'bg-rose-500/10 border border-rose-500/20',
+        step.status === 'running' && 'bg-[color-mix(in_srgb,var(--info)_10%,transparent)] border border-[color-mix(in_srgb,var(--info)_20%,transparent)]',
+        step.status === 'failed' && 'bg-[color-mix(in_srgb,var(--danger)_10%,transparent)] border border-[color-mix(in_srgb,var(--danger)_20%,transparent)]',
         step.status === 'completed' && 'bg-zinc-900/40 border border-zinc-800/40',
         step.status === 'pending' && 'opacity-60',
       )}
@@ -49,27 +49,27 @@ export function OperationStepRow({ step }: { step: OperationStep }) {
           <span
             className={cn(
               'font-medium truncate',
-              step.status === 'running' && 'text-sky-200 font-semibold',
-              step.status === 'failed' && 'text-rose-200 font-semibold',
-              step.status === 'completed' && 'text-zinc-200',
-              step.status === 'pending' && 'text-zinc-400',
+              step.status === 'running' && 'text-[var(--info-strong)] font-semibold',
+              step.status === 'failed' && 'text-[var(--danger-strong)] font-semibold',
+              step.status === 'completed' && 'text-[var(--muted-strong)]',
+              step.status === 'pending' && 'text-[var(--muted)]',
             )}
           >
             {step.label}
           </span>
           {typeof step.current === 'number' && typeof step.total === 'number' && (
-            <span className="text-[10px] font-mono text-zinc-400">
+            <span className="text-[10px] font-mono text-[var(--muted)]">
               {step.current}/{step.total}
             </span>
           )}
         </div>
         {step.detail && (
-          <p className="mt-0.5 text-[11px] text-zinc-400 leading-relaxed break-words">
+          <p className="mt-0.5 text-[11px] text-[var(--muted)] leading-relaxed break-words">
             {step.detail}
           </p>
         )}
         {step.error && (
-          <p className="mt-1 text-[11px] text-rose-300 font-mono bg-rose-950/40 border border-rose-800/40 rounded px-2 py-1 leading-normal">
+          <p className="mt-1 text-[11px] text-[var(--danger)] font-mono bg-[color-mix(in_srgb,var(--danger)_15%,transparent)] border border-[color-mix(in_srgb,var(--danger)_30%,transparent)] rounded px-2 py-1 leading-normal">
             {step.error.message}
           </p>
         )}
@@ -109,8 +109,8 @@ export function OperationProgressView({
   if (loading && !snapshot) {
     return (
       <div className="flex flex-col items-center justify-center p-8 text-center space-y-3" role="status">
-        <LoaderCircle className="size-6 animate-spin text-sky-400" />
-        <p className="text-xs text-zinc-400">Inicjalizacja operacji…</p>
+        <LoaderCircle className="size-6 animate-spin text-[var(--info)]" />
+        <p className="text-xs text-[var(--muted)]">Inicjalizacja operacji…</p>
       </div>
     );
   }
@@ -118,7 +118,7 @@ export function OperationProgressView({
   if (error && !snapshot) {
     return (
       <div className="p-6 space-y-4">
-        <div className="flex items-center gap-2.5 text-rose-300 bg-rose-950/30 border border-rose-800/40 rounded-lg p-3 text-xs">
+        <div className="flex items-center gap-2.5 text-[var(--danger)] bg-[color-mix(in_srgb,var(--danger)_12%,transparent)] border border-[color-mix(in_srgb,var(--danger)_30%,transparent)] rounded-lg p-3 text-xs">
           <AlertTriangle className="size-4 shrink-0" />
           <span>{error}</span>
         </div>
@@ -153,18 +153,18 @@ export function OperationProgressView({
       )}
 
       {isFailed && snapshot.error && (
-        <div className="rounded-lg border border-rose-500/30 bg-rose-950/40 p-3 text-rose-200 space-y-1">
+        <div className="rounded-lg border border-[color-mix(in_srgb,var(--danger)_30%,transparent)] bg-[color-mix(in_srgb,var(--danger)_15%,transparent)] p-3 text-[var(--danger-strong)] space-y-1">
           <p className="font-semibold text-xs flex items-center gap-1.5">
-            <AlertTriangle className="size-3.5 text-rose-400" /> Operacja nie powiodła się
+            <AlertTriangle className="size-3.5 text-[var(--danger)]" /> Operacja nie powiodła się
           </p>
-          <p className="text-[11px] leading-relaxed font-mono text-rose-300">
+          <p className="text-[11px] leading-relaxed font-mono text-[var(--danger)]">
             {snapshot.error.message}
           </p>
         </div>
       )}
 
       {isCompleted && resultSummary && (
-        <p className="text-[11px] text-zinc-400 italic px-1">
+        <p className="text-[11px] text-[var(--muted)] italic px-1">
           {resultSummary}
         </p>
       )}
@@ -243,17 +243,17 @@ export function OperationModal({
           </h2>
           <div className="flex items-center gap-3 shrink-0">
             {isRunning && (
-              <span className="inline-flex items-center gap-1.5 font-medium text-sky-400 text-xs">
+              <span className="inline-flex items-center gap-1.5 font-medium text-[var(--info)] text-xs">
                 <LoaderCircle className="size-3.5 animate-spin" /> W toku…
               </span>
             )}
             {isCompleted && (
-              <span className="inline-flex items-center gap-1.5 font-medium text-emerald-400 text-xs">
+              <span className="inline-flex items-center gap-1.5 font-medium text-[var(--success)] text-xs">
                 <CheckCircle2 className="size-3.5" /> Ukończono
               </span>
             )}
             {isFailed && (
-              <span className="inline-flex items-center gap-1.5 font-medium text-rose-400 text-xs">
+              <span className="inline-flex items-center gap-1.5 font-medium text-[var(--danger)] text-xs">
                 <AlertCircle className="size-3.5" /> Błąd
               </span>
             )}

--- a/tools/dashboard/src/components/spec-actions.tsx
+++ b/tools/dashboard/src/components/spec-actions.tsx
@@ -69,11 +69,11 @@ export function RepositoryActionsCard({
           <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-[var(--muted)]">Workflow</p>
           <div className="mt-2 flex flex-wrap items-center gap-2">
             <Badge className={worktree.clean
-              ? 'border-emerald-300/20 bg-emerald-300/8 text-emerald-200'
-              : 'border-amber-300/20 bg-amber-300/8 text-amber-200'}>
+              ? 'border-[color-mix(in_srgb,var(--success)_20%,transparent)] bg-[color-mix(in_srgb,var(--success)_8%,transparent)] text-[var(--success)]'
+              : 'border-[color-mix(in_srgb,var(--warning)_20%,transparent)] bg-[color-mix(in_srgb,var(--warning)_8%,transparent)] text-[var(--warning)]'}>
               {worktree.clean ? 'Worktree czysty' : `${worktree.total} zmian bez commita`}
             </Badge>
-            <Badge className={synchronized ? 'text-[var(--muted-strong)]' : 'border-amber-300/20 text-amber-200'}>
+            <Badge className={synchronized ? 'text-[var(--muted-strong)]' : 'border-[color-mix(in_srgb,var(--warning)_20%,transparent)] text-[var(--warning)]'}>
               {synchronized ? 'Branch zsynchronizowany' : 'Git wymaga uwagi'}
             </Badge>
           </div>
@@ -89,7 +89,7 @@ export function RepositoryActionsCard({
         {worktree.hasUpstream ? (
           <p className="flex items-center gap-2"><GitCommitHorizontal className="size-3.5" />Ahead {worktree.ahead ?? 0} · behind {worktree.behind ?? 0}</p>
         ) : (
-          <p className="text-amber-200/80">Branch nie ma upstreamu.</p>
+          <p className="text-[color-mix(in_srgb,var(--warning-strong)_80%,transparent)]">Branch nie ma upstreamu.</p>
         )}
       </div>
 
@@ -195,7 +195,7 @@ export function FinalizeDialog({
       <div ref={dialogRef} role="alertdialog" aria-modal="true" aria-labelledby="finalize-dialog-title" className="w-full max-w-lg overflow-hidden rounded-t-2xl border border-[var(--border)] bg-[var(--background)] shadow-2xl sm:rounded-2xl">
         <div className="flex items-start justify-between gap-4 border-b border-[var(--border)] bg-[var(--surface)] px-5 py-4 sm:px-6">
           <div>
-            <Badge className="border-amber-300/20 bg-amber-300/8 text-amber-200">Operacja końcowa</Badge>
+            <Badge className="border-[color-mix(in_srgb,var(--warning)_20%,transparent)] bg-[color-mix(in_srgb,var(--warning)_8%,transparent)] text-[var(--warning)]">Operacja końcowa</Badge>
             <h2 id="finalize-dialog-title" className="mt-3 text-lg font-semibold text-[var(--foreground)]">Finalizować specyfikację?</h2>
           </div>
           <Button variant="ghost" size="icon" disabled={executing} onClick={onClose} aria-label="Zamknij dialog finalizacji"><X className="size-4" /></Button>

--- a/tools/dashboard/src/components/spec-actions.tsx
+++ b/tools/dashboard/src/components/spec-actions.tsx
@@ -146,7 +146,7 @@ export function TaskActionFooter({
     <div className="flex flex-col gap-3 border-t border-[var(--border)] bg-[var(--surface)] px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-7">
       <div className="min-w-0">
         <p className="text-xs font-semibold text-[var(--foreground)]">Akcja właściciela</p>
-        <p className={cn('mt-1 text-[10px] leading-4', error ? 'text-red-300' : 'text-[var(--muted)]')}>
+        <p className={cn('mt-1 text-[10px] leading-4', error ? 'text-[var(--danger-strong)]' : 'text-[var(--muted)]')}>
           {error || gate.reason || 'Bramka workflow przeszła — akcja jest dostępna.'}
         </p>
       </div>
@@ -209,7 +209,7 @@ export function FinalizeDialog({
             <li>scali pull request,</li>
             <li>uruchomi kontrolę po merge i posprząta branch.</li>
           </ol>
-          {error && <div className="mt-4 flex gap-2 rounded-lg border border-red-300/20 bg-red-300/8 px-3 py-2 text-red-200"><AlertTriangle className="mt-0.5 size-3.5 shrink-0" />{error}</div>}
+          {error && <div className="mt-4 flex gap-2 rounded-lg border border-[color-mix(in_srgb,var(--danger)_20%,transparent)] bg-[color-mix(in_srgb,var(--danger)_8%,transparent)] px-3 py-2 text-[var(--danger-strong)]"><AlertTriangle className="mt-0.5 size-3.5 shrink-0" />{error}</div>}
         </div>
         <div className="flex justify-end gap-2 border-t border-[var(--border)] bg-[var(--surface)] px-5 py-4 sm:px-6">
           <Button ref={cancelRef} variant="secondary" size="sm" disabled={executing} onClick={onClose}>Anuluj</Button>

--- a/tools/dashboard/src/components/stage-progress.tsx
+++ b/tools/dashboard/src/components/stage-progress.tsx
@@ -7,7 +7,7 @@ const visibleStages: Array<{ id: StageId; label: string; color: string }> = [
   { id: 'implementation', label: 'Implementacja', color: 'bg-amber-300/60' },
   { id: 'ready', label: 'Ready', color: 'bg-sky-400/60' },
   { id: 'design', label: 'Projekt', color: 'bg-violet-400/60' },
-  { id: 'new', label: 'Nowe', color: 'bg-slate-400/25' },
+  { id: 'new', label: 'Nowe', color: 'bg-[color-mix(in_srgb,var(--muted)_25%,transparent)]' },
 ];
 
 export function StageProgress({

--- a/tools/dashboard/src/components/status-board.tsx
+++ b/tools/dashboard/src/components/status-board.tsx
@@ -13,11 +13,11 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 
 const stageTone: Record<StageId, { dot: string; tint: string; line: string }> = {
-  new: { dot: 'bg-slate-400', tint: 'bg-slate-400/7', line: 'border-slate-400/25' },
-  design: { dot: 'bg-violet-400', tint: 'bg-violet-400/7', line: 'border-violet-400/25' },
-  ready: { dot: 'bg-sky-400', tint: 'bg-sky-400/7', line: 'border-sky-400/25' },
-  implementation: { dot: 'bg-amber-300', tint: 'bg-amber-300/7', line: 'border-amber-300/25' },
-  review: { dot: 'bg-fuchsia-400', tint: 'bg-fuchsia-400/7', line: 'border-fuchsia-400/25' },
+  new: { dot: 'bg-[var(--muted)]', tint: 'bg-[color-mix(in_srgb,var(--muted)_7%,transparent)]', line: 'border-[color-mix(in_srgb,var(--muted)_25%,transparent)]' },
+  design: { dot: 'bg-[var(--muted)]', tint: 'bg-[color-mix(in_srgb,var(--muted)_7%,transparent)]', line: 'border-[color-mix(in_srgb,var(--muted)_25%,transparent)]' },
+  ready: { dot: 'bg-[var(--muted)]', tint: 'bg-[color-mix(in_srgb,var(--muted)_7%,transparent)]', line: 'border-[color-mix(in_srgb,var(--muted)_25%,transparent)]' },
+  implementation: { dot: 'bg-[var(--info)]', tint: 'bg-[color-mix(in_srgb,var(--info)_7%,transparent)]', line: 'border-[color-mix(in_srgb,var(--info)_25%,transparent)]' },
+  review: { dot: 'bg-[var(--warning)]', tint: 'bg-[color-mix(in_srgb,var(--warning)_7%,transparent)]', line: 'border-[color-mix(in_srgb,var(--warning)_25%,transparent)]' },
   done: { dot: 'bg-[var(--accent)]', tint: 'bg-[color-mix(in_srgb,var(--accent)_7%,transparent)]', line: 'border-[color-mix(in_srgb,var(--accent)_25%,transparent)]' },
 };
 

--- a/tools/dashboard/src/components/ui/status-card.tsx
+++ b/tools/dashboard/src/components/ui/status-card.tsx
@@ -87,19 +87,19 @@ export function StatusCard({
 
   const containerStyles = cn(
     'group relative flex min-w-0 items-center justify-between gap-4 rounded-xl border transition-colors',
-    isError && 'border-rose-500/20 bg-rose-500/5 text-rose-200',
-    isWarning && 'border-amber-500/20 bg-amber-500/5 text-amber-200',
+    isError && 'border-[color-mix(in_srgb,var(--danger)_20%,transparent)] bg-[color-mix(in_srgb,var(--danger)_5%,transparent)] text-[var(--danger)]',
+    isWarning && 'border-[color-mix(in_srgb,var(--warning)_20%,transparent)] bg-[color-mix(in_srgb,var(--warning)_5%,transparent)] text-[var(--warning)]',
     variant === 'info' && 'border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)]',
     size === 'sm' ? 'p-3 text-xs' : 'p-4 sm:p-5 text-sm',
     className,
   );
 
   const Icon = isError ? AlertCircle : isWarning ? AlertTriangle : Info;
-  const iconColor = isError ? 'text-rose-400' : isWarning ? 'text-amber-400' : 'text-[var(--accent)]';
+  const iconColor = isError ? 'text-[var(--danger)]' : isWarning ? 'text-[var(--warning)]' : 'text-[var(--accent)]';
   const iconBadgeStyles = cn(
     'flex size-8 shrink-0 items-center justify-center rounded-lg border',
-    isError && 'border-rose-500/20 bg-rose-500/10',
-    isWarning && 'border-amber-500/20 bg-amber-500/10',
+    isError && 'border-[color-mix(in_srgb,var(--danger)_20%,transparent)] bg-[color-mix(in_srgb,var(--danger)_10%,transparent)]',
+    isWarning && 'border-[color-mix(in_srgb,var(--warning)_20%,transparent)] bg-[color-mix(in_srgb,var(--warning)_10%,transparent)]',
     variant === 'info' && 'border-[var(--border)] bg-[var(--surface-raised)]',
   );
 

--- a/tools/dashboard/src/index.css
+++ b/tools/dashboard/src/index.css
@@ -13,6 +13,16 @@
   --muted-strong: #a8b0bb;
   --accent: #c8f85a;
   --accent-strong: #d7ff78;
+  --success: #34d399;
+  --success-strong: #6ee7b7;
+  --warning: #fbbf24;
+  --warning-strong: #fde68a;
+  --danger: #fb7185;
+  --danger-strong: #fecdd3;
+  --info: #38bdf8;
+  --info-strong: #bae6fd;
+  --cat-1: #fb923c;
+  --cat-2: #c084fc;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
Add 10 CSS custom properties to index.css (--success/--warning/--danger/--info, each with a -strong variant, plus --cat-1/--cat-2 categorical identifiers) and migrate every hardcoded Tailwind color usage at their cited sites to reference them, deriving -bg/-border tints via the existing color-mix() precedent (status-board.tsx:21) rather than a new derivation mechanism.

Also migrates ui/status-card.tsx's isWarning branch (amber-500), which sits directly beside the isError branch this task's own citation list already covers and is actively rendered via StatusCard variant="warning" in ai-session-list.tsx, app-sidebar.tsx, and spec-actions.tsx — left unmigrated it would have kept exactly the raw-amber/--warning duplication this task exists to remove, in the same file already being edited.

## Summary

<!-- What does this PR do and why? -->

## Related artifacts

- Spec: <!-- specs/active/<slug>/ or "none (Class S)" -->
- Task: <!-- specs/active/<slug>/tasks/<task>.md or "n/a" -->
- ADR: <!-- docs/decisions/ADR-XXXX-*.md or "none" -->

## Changes

<!-- What was changed? Keep it to a few bullet points. -->

## Verification

<!-- How was this verified? Tests run, manual steps, etc. -->

## Documentation impact

<!-- Was docs/development/ updated? If not, why not? -->

## Breaking changes

<!-- none / describe the behavior change -->

## Follow-ups

<!-- Anything deferred? Link to follow-up spec or issue. -->
